### PR TITLE
Simplify request code

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6,7 +6,7 @@ import { Shipments } from './resources/Shipments';
 import { Stores } from './resources/Stores';
 import { Warehouses } from './resources/Warehouses';
 import { Webhooks } from './resources/Webhooks';
-import Shipstation, { RequestMethod } from './shipstation';
+import Shipstation from './shipstation';
 import { Products } from './resources/Products';
 export default class ShipStationAPI {
     constructor(options) {
@@ -22,4 +22,4 @@ export default class ShipStationAPI {
         this.request = this.ss.request;
     }
 }
-export { Models, RequestMethod };
+export { Models };

--- a/dist/resources/Base.js
+++ b/dist/resources/Base.js
@@ -7,7 +7,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import { RequestMethod } from '../shipstation';
 export class BaseResource {
     constructor(shipstation, baseUrl) {
         this.shipstation = shipstation;
@@ -17,22 +16,10 @@ export class BaseResource {
     }
     get(id) {
         return __awaiter(this, void 0, void 0, function* () {
-            const url = `${this.baseUrl}/${id}`;
-            const response = yield this.shipstation.request({
-                url,
-                method: RequestMethod.GET
+            return this.shipstation.request({
+                url: `${this.baseUrl}/${id}`,
+                method: 'GET'
             });
-            return response.data;
         });
-    }
-    buildQueryStringFromParams(params) {
-        let qs = '';
-        if (typeof params !== 'undefined') {
-            Object.entries(params).forEach(([key, value], index) => {
-                const qsStart = index === 0 ? '?' : '&';
-                qs += `${qsStart}${key}=${value}`;
-            });
-        }
-        return qs;
     }
 }

--- a/dist/resources/Carriers.js
+++ b/dist/resources/Carriers.js
@@ -7,7 +7,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import { RequestMethod } from '../shipstation';
 import { BaseResource } from './Base';
 export class Carriers extends BaseResource {
     constructor(shipstation) {
@@ -16,12 +15,10 @@ export class Carriers extends BaseResource {
     }
     getAll() {
         return __awaiter(this, void 0, void 0, function* () {
-            const url = this.baseUrl;
-            const response = yield this.shipstation.request({
-                url,
-                method: RequestMethod.GET
+            return this.shipstation.request({
+                url: this.baseUrl,
+                method: 'GET'
             });
-            return response.data;
         });
     }
 }

--- a/dist/resources/Fulfillments.js
+++ b/dist/resources/Fulfillments.js
@@ -7,22 +7,19 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import { RequestMethod } from '../shipstation';
 import { BaseResource } from './Base';
 export class Fulfillments extends BaseResource {
     constructor(shipstation) {
         super(shipstation, 'fulfillments');
         this.shipstation = shipstation;
     }
-    getAll(opts) {
+    getAll(params) {
         return __awaiter(this, void 0, void 0, function* () {
-            const query = this.buildQueryStringFromParams(opts);
-            const url = this.baseUrl + query;
-            const response = yield this.shipstation.request({
-                url,
-                method: RequestMethod.GET
+            return this.shipstation.request({
+                url: this.baseUrl,
+                method: 'GET',
+                params
             });
-            return response.data;
         });
     }
 }

--- a/dist/resources/Orders.js
+++ b/dist/resources/Orders.js
@@ -7,55 +7,46 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import { RequestMethod } from '../shipstation';
 import { BaseResource } from './Base';
 export class Orders extends BaseResource {
     constructor(shipstation) {
         super(shipstation, 'orders');
         this.shipstation = shipstation;
     }
-    getAll(opts) {
+    getAll(params) {
         return __awaiter(this, void 0, void 0, function* () {
-            const query = this.buildQueryStringFromParams(opts);
-            const url = this.baseUrl + query;
-            const response = yield this.shipstation.request({
-                url,
-                method: RequestMethod.GET
+            return this.shipstation.request({
+                url: this.baseUrl,
+                method: 'GET',
+                params
             });
-            return response.data;
         });
     }
     createOrUpdate(data) {
         return __awaiter(this, void 0, void 0, function* () {
-            const url = `${this.baseUrl}/createorder`;
-            const response = yield this.shipstation.request({
-                url,
-                method: RequestMethod.POST,
+            return this.shipstation.request({
+                url: `${this.baseUrl}/createorder`,
+                method: 'POST',
                 data
             });
-            return response.data;
         });
     }
     createOrUpdateBulk(data) {
         return __awaiter(this, void 0, void 0, function* () {
-            const url = `${this.baseUrl}/createorders`;
-            const response = yield this.shipstation.request({
-                url,
-                method: RequestMethod.POST,
+            return this.shipstation.request({
+                url: `${this.baseUrl}/createorders`,
+                method: 'POST',
                 data
             });
-            return response.data;
         });
     }
     createLabel(data) {
         return __awaiter(this, void 0, void 0, function* () {
-            const url = `${this.baseUrl}/createlabelfororder`;
-            const response = yield this.shipstation.request({
-                url,
-                method: RequestMethod.POST,
+            return this.shipstation.request({
+                url: `${this.baseUrl}/createlabelfororder`,
+                method: 'POST',
                 data
             });
-            return response.data;
         });
     }
 }

--- a/dist/resources/Products.js
+++ b/dist/resources/Products.js
@@ -7,22 +7,19 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import { RequestMethod } from '../shipstation';
 import { BaseResource } from './Base';
 export class Products extends BaseResource {
     constructor(shipstation) {
         super(shipstation, 'products');
         this.shipstation = shipstation;
     }
-    getAll(opts) {
+    getAll(params) {
         return __awaiter(this, void 0, void 0, function* () {
-            const query = this.buildQueryStringFromParams(opts);
-            const url = this.baseUrl + query;
-            const response = yield this.shipstation.request({
-                url,
-                method: RequestMethod.GET
+            return this.shipstation.request({
+                url: this.baseUrl,
+                method: 'GET',
+                params
             });
-            return response.data;
         });
     }
     update(data) {
@@ -30,13 +27,11 @@ export class Products extends BaseResource {
             if (!data.productId) {
                 throw new Error('Product ID is required');
             }
-            const url = `${this.baseUrl}/${data.productId}`;
-            const response = yield this.shipstation.request({
-                url,
-                method: RequestMethod.PUT,
+            return this.shipstation.request({
+                url: `${this.baseUrl}/${data.productId}`,
+                method: 'PUT',
                 data
             });
-            return response.data;
         });
     }
 }

--- a/dist/resources/Shipments.js
+++ b/dist/resources/Shipments.js
@@ -7,55 +7,46 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import { RequestMethod } from '../shipstation';
 import { BaseResource } from './Base';
 export class Shipments extends BaseResource {
     constructor(shipstation) {
         super(shipstation, 'shipments');
         this.shipstation = shipstation;
     }
-    getAll(opts) {
+    getAll(params) {
         return __awaiter(this, void 0, void 0, function* () {
-            const query = this.buildQueryStringFromParams(opts);
-            const url = this.baseUrl + query;
-            const response = yield this.shipstation.request({
-                url,
-                method: RequestMethod.GET
+            return this.shipstation.request({
+                url: this.baseUrl,
+                method: 'GET',
+                params
             });
-            return response.data;
         });
     }
     getRates(data) {
         return __awaiter(this, void 0, void 0, function* () {
-            const url = this.baseUrl + '/getrates';
-            const response = yield this.shipstation.request({
-                url,
-                method: RequestMethod.POST,
+            return this.shipstation.request({
+                url: `${this.baseUrl}/getrates`,
+                method: 'POST',
                 data
             });
-            return response.data;
         });
     }
     createLabel(data) {
         return __awaiter(this, void 0, void 0, function* () {
-            const url = this.baseUrl + '/createlabel';
-            const response = yield this.shipstation.request({
-                url,
-                method: RequestMethod.POST,
+            return this.shipstation.request({
+                url: `${this.baseUrl}/createlabel`,
+                method: 'POST',
                 data
             });
-            return response.data;
         });
     }
     voidLabel(data) {
         return __awaiter(this, void 0, void 0, function* () {
-            const url = this.baseUrl + '/voidlabel';
-            const response = yield this.shipstation.request({
-                url,
-                method: RequestMethod.POST,
+            return this.shipstation.request({
+                url: `${this.baseUrl}/voidlabel`,
+                method: 'POST',
                 data
             });
-            return response.data;
         });
     }
 }

--- a/dist/resources/Stores.js
+++ b/dist/resources/Stores.js
@@ -7,30 +7,19 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import { RequestMethod } from '../shipstation';
 import { BaseResource } from './Base';
 export class Stores extends BaseResource {
     constructor(shipstation) {
         super(shipstation, 'stores');
         this.shipstation = shipstation;
     }
-    getAll(opts) {
+    getAll(params) {
         return __awaiter(this, void 0, void 0, function* () {
-            let url = this.baseUrl;
-            if (typeof opts !== 'undefined') {
-                if (typeof opts.showInactive !== 'undefined') {
-                    url += `?showInactive=${opts.showInactive}`;
-                }
-                if (typeof opts.marketplaceId !== 'undefined') {
-                    const marketplaceQuery = `marketplaceId=${opts.marketplaceId}`;
-                    url += url.includes('?') ? `&${marketplaceQuery}` : `?${marketplaceQuery}`;
-                }
-            }
-            const response = yield this.shipstation.request({
-                url,
-                method: RequestMethod.GET
+            return this.shipstation.request({
+                params,
+                url: this.baseUrl,
+                method: 'GET'
             });
-            return response.data;
         });
     }
 }

--- a/dist/resources/Warehouses.js
+++ b/dist/resources/Warehouses.js
@@ -7,54 +7,44 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import { RequestMethod } from '../shipstation';
 import { BaseResource } from './Base';
 export class Warehouses extends BaseResource {
     constructor(shipstation) {
         super(shipstation, 'warehouses');
         this.shipstation = shipstation;
     }
-    getAll(opts) {
+    getAll() {
         return __awaiter(this, void 0, void 0, function* () {
-            const query = this.buildQueryStringFromParams(opts);
-            const url = this.baseUrl + query;
-            const response = yield this.shipstation.request({
-                url,
-                method: RequestMethod.GET
+            return this.shipstation.request({
+                url: this.baseUrl,
+                method: 'GET'
             });
-            return response.data;
         });
     }
     create(data) {
         return __awaiter(this, void 0, void 0, function* () {
-            const url = `${this.baseUrl}/createwarehouse`;
-            const response = yield this.shipstation.request({
-                url,
-                method: RequestMethod.POST,
+            return this.shipstation.request({
+                url: `${this.baseUrl}/createwarehouse`,
+                method: 'POST',
                 data
             });
-            return response.data;
         });
     }
     update(id, data) {
         return __awaiter(this, void 0, void 0, function* () {
-            const url = `${this.baseUrl}/${id}`;
-            const response = yield this.shipstation.request({
-                url,
-                method: RequestMethod.PUT,
+            return this.shipstation.request({
+                url: `${this.baseUrl}/${id}`,
+                method: 'PUT',
                 data
             });
-            return response.data;
         });
     }
     delete(id) {
         return __awaiter(this, void 0, void 0, function* () {
-            const url = `${this.baseUrl}/${id}`;
-            const response = yield this.shipstation.request({
-                url,
-                method: RequestMethod.DELETE
+            return this.shipstation.request({
+                url: `${this.baseUrl}/${id}`,
+                method: 'DELETE'
             });
-            return response.data;
         });
     }
 }

--- a/dist/resources/Webhooks.js
+++ b/dist/resources/Webhooks.js
@@ -7,7 +7,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import { RequestMethod } from '../shipstation';
 import { BaseResource } from './Base';
 export class Webhooks extends BaseResource {
     constructor(shipstation) {
@@ -16,31 +15,26 @@ export class Webhooks extends BaseResource {
     }
     getAll() {
         return __awaiter(this, void 0, void 0, function* () {
-            const url = this.baseUrl;
-            const response = yield this.shipstation.request({
-                url,
-                method: RequestMethod.GET
+            return this.shipstation.request({
+                url: this.baseUrl,
+                method: 'GET'
             });
-            return response.data;
         });
     }
     subscribe(data) {
         return __awaiter(this, void 0, void 0, function* () {
-            const url = `${this.baseUrl}/subscribe`;
-            const response = yield this.shipstation.request({
-                url,
-                method: RequestMethod.POST,
+            return this.shipstation.request({
+                url: `${this.baseUrl}/subscribe`,
+                method: 'POST',
                 data
             });
-            return response.data;
         });
     }
     unsubscribe(id) {
         return __awaiter(this, void 0, void 0, function* () {
-            const url = `${this.baseUrl}/${id}`;
             yield this.shipstation.request({
-                url,
-                method: RequestMethod.DELETE
+                url: `${this.baseUrl}/${id}`,
+                method: 'DELETE'
             });
             return null;
         });

--- a/dist/shipstation.js
+++ b/dist/shipstation.js
@@ -1,3 +1,12 @@
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 import axios from 'axios';
 import axiosRetry from 'axios-retry';
 const stopcock = require('stopcock');
@@ -5,37 +14,20 @@ const RATE_LIMIT_OPTS = {
     limit: 40,
     interval: 1000 * 40
 };
-export const RequestMethod = {
-    GET: 'GET',
-    POST: 'POST',
-    PUT: 'PUT',
-    DELETE: 'DELETE'
-};
 export default class Shipstation {
     constructor(options) {
         this.baseUrl = 'https://ssapi.shipstation.com/';
-        this.request = ({ url, method = RequestMethod.GET, useBaseUrl = true, data }) => {
-            const opts = {
-                headers: {
-                    Authorization: `Basic ${this.authorizationToken}`
-                },
+        this.request = (_a) => __awaiter(this, [_a], void 0, function* ({ data, method = 'GET', params, url }) {
+            const response = yield axios.request({
+                headers: Object.assign({ Authorization: `Basic ${this.authorizationToken}` }, (this.partnerKey ? { 'x-partner': this.partnerKey } : {})),
+                data,
                 method,
-                url: `${useBaseUrl ? this.baseUrl : ''}${url}`
-            };
-            if (!opts.headers) {
-                opts.headers = {};
-            }
-            if (this.partnerKey) {
-                opts.headers['x-partner'] = this.partnerKey;
-            }
-            if (data) {
-                opts.data = data;
-            }
-            if (this.timeout) {
-                opts.timeout = this.timeout;
-            }
-            return axios.request(opts);
-        };
+                params,
+                timeout: this.timeout,
+                url
+            });
+            return response.data;
+        });
         const key = (options === null || options === void 0 ? void 0 : options.apiKey) ? options.apiKey : process.env.SS_API_KEY;
         const secret = (options === null || options === void 0 ? void 0 : options.apiSecret) ? options.apiSecret : process.env.SS_API_SECRET;
         this.partnerKey = (options === null || options === void 0 ? void 0 : options.partnerKey) ? options.partnerKey : process.env.SS_PARTNER_KEY;

--- a/dist/shipstation.js
+++ b/dist/shipstation.js
@@ -16,9 +16,9 @@ const RATE_LIMIT_OPTS = {
 };
 export default class Shipstation {
     constructor(options) {
-        this.baseUrl = 'https://ssapi.shipstation.com/';
         this.request = (_a) => __awaiter(this, [_a], void 0, function* ({ data, method = 'GET', params, url }) {
             const response = yield axios.request({
+                baseURL: 'https://ssapi.shipstation.com/',
                 headers: Object.assign({ Authorization: `Basic ${this.authorizationToken}` }, (this.partnerKey ? { 'x-partner': this.partnerKey } : {})),
                 data,
                 method,

--- a/package.json
+++ b/package.json
@@ -38,5 +38,5 @@
     "lint": "eslint --max-warnings 0 --config=eslint.config.js"
   },
   "types": "typings/index.d.ts",
-  "version": "0.25.1"
+  "version": "0.26.0"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { Stores } from './resources/Stores';
 import { Warehouses } from './resources/Warehouses';
 import { Webhooks } from './resources/Webhooks';
 import type { IShipstationRequestOptions, IShipstationOptions } from './shipstation';
-import Shipstation, { RequestMethod } from './shipstation';
+import Shipstation from './shipstation';
 import { Products } from './resources/Products';
 
 export default class ShipStationAPI {
@@ -41,4 +41,4 @@ export default class ShipStationAPI {
 }
 
 export type { IShipstationRequestOptions };
-export { Models, RequestMethod };
+export { Models };

--- a/src/resources/Base.ts
+++ b/src/resources/Base.ts
@@ -1,6 +1,6 @@
 import type Shipstation from '../shipstation';
 
-export class BaseResource<T> {
+export abstract class BaseResource<T> {
   constructor(
     protected shipstation: Shipstation,
     protected baseUrl: string

--- a/src/resources/Base.ts
+++ b/src/resources/Base.ts
@@ -1,5 +1,4 @@
 import type Shipstation from '../shipstation';
-import { RequestMethod } from '../shipstation';
 
 export class BaseResource<T> {
   constructor(
@@ -11,24 +10,9 @@ export class BaseResource<T> {
   }
 
   public async get(id: number): Promise<T> {
-    const url = `${this.baseUrl}/${id}`;
-    const response = await this.shipstation.request({
-      url,
-      method: RequestMethod.GET
+    return this.shipstation.request<T>({
+      url: `${this.baseUrl}/${id}`,
+      method: 'GET'
     });
-    return response.data as T;
-  }
-
-  protected buildQueryStringFromParams(params?: object) {
-    let qs = '';
-
-    if (typeof params !== 'undefined') {
-      Object.entries(params).forEach(([key, value], index) => {
-        const qsStart = index === 0 ? '?' : '&';
-        qs += `${qsStart}${key}=${value}`;
-      });
-    }
-
-    return qs;
   }
 }

--- a/src/resources/Carriers.ts
+++ b/src/resources/Carriers.ts
@@ -1,6 +1,5 @@
 import type { ICarrier } from '../models';
 import type Shipstation from '../shipstation';
-import { RequestMethod } from '../shipstation';
 import { BaseResource } from './Base';
 
 export class Carriers extends BaseResource<ICarrier> {
@@ -9,11 +8,9 @@ export class Carriers extends BaseResource<ICarrier> {
   }
 
   public async getAll(): Promise<Array<ICarrier>> {
-    const url = this.baseUrl;
-    const response = await this.shipstation.request({
-      url,
-      method: RequestMethod.GET
+    return this.shipstation.request<Array<ICarrier>>({
+      url: this.baseUrl,
+      method: 'GET'
     });
-    return response.data as Array<ICarrier>;
   }
 }

--- a/src/resources/Fulfillments.ts
+++ b/src/resources/Fulfillments.ts
@@ -1,6 +1,5 @@
 import type { IFulfillment, IFulfillmentPaginationResult } from '../models';
 import type Shipstation from '../shipstation';
-import { RequestMethod } from '../shipstation';
 import { BaseResource } from './Base';
 
 export class Fulfillments extends BaseResource<IFulfillment> {
@@ -8,14 +7,11 @@ export class Fulfillments extends BaseResource<IFulfillment> {
     super(shipstation, 'fulfillments');
   }
 
-  public async getAll(opts?: object): Promise<IFulfillmentPaginationResult> {
-    const query = this.buildQueryStringFromParams(opts);
-    const url = this.baseUrl + query;
-
-    const response = await this.shipstation.request({
-      url,
-      method: RequestMethod.GET
+  public async getAll(params?: object): Promise<IFulfillmentPaginationResult> {
+    return this.shipstation.request<IFulfillmentPaginationResult>({
+      url: this.baseUrl,
+      method: 'GET',
+      params
     });
-    return response.data as IFulfillmentPaginationResult;
   }
 }

--- a/src/resources/Orders.ts
+++ b/src/resources/Orders.ts
@@ -7,7 +7,6 @@ import type {
   ICreateLabelResponse
 } from '../models';
 import type Shipstation from '../shipstation';
-import { RequestMethod } from '../shipstation';
 import { BaseResource } from './Base';
 
 export class Orders extends BaseResource<IOrder> {
@@ -15,46 +14,35 @@ export class Orders extends BaseResource<IOrder> {
     super(shipstation, 'orders');
   }
 
-  public async getAll(opts?: object): Promise<IOrderPaginationResult> {
-    const query = this.buildQueryStringFromParams(opts);
-    const url = this.baseUrl + query;
-
-    const response = await this.shipstation.request({
-      url,
-      method: RequestMethod.GET
+  public async getAll(params?: object): Promise<IOrderPaginationResult> {
+    return this.shipstation.request<IOrderPaginationResult>({
+      url: this.baseUrl,
+      method: 'GET',
+      params
     });
-    return response.data as IOrderPaginationResult;
   }
 
   public async createOrUpdate(data: ICreateOrUpdateOrder): Promise<IOrder> {
-    const url = `${this.baseUrl}/createorder`;
-    const response = await this.shipstation.request({
-      url,
-      method: RequestMethod.POST,
+    return this.shipstation.request<IOrder>({
+      url: `${this.baseUrl}/createorder`,
+      method: 'POST',
       data
     });
-    return response.data as IOrder;
   }
 
   public async createOrUpdateBulk(data: Array<ICreateOrUpdateOrder>): Promise<ICreateOrUpdateOrderBulkResponse> {
-    const url = `${this.baseUrl}/createorders`;
-    const response = await this.shipstation.request({
-      url,
-      method: RequestMethod.POST,
+    return this.shipstation.request<ICreateOrUpdateOrderBulkResponse>({
+      url: `${this.baseUrl}/createorders`,
+      method: 'POST',
       data
     });
-
-    return response.data as ICreateOrUpdateOrderBulkResponse;
   }
 
   public async createLabel(data: ICreateLabel): Promise<ICreateLabelResponse> {
-    const url = `${this.baseUrl}/createlabelfororder`;
-    const response = await this.shipstation.request({
-      url,
-      method: RequestMethod.POST,
+    return this.shipstation.request<ICreateLabelResponse>({
+      url: `${this.baseUrl}/createlabelfororder`,
+      method: 'POST',
       data
     });
-
-    return response.data as ICreateLabelResponse;
   }
 }

--- a/src/resources/Products.ts
+++ b/src/resources/Products.ts
@@ -1,6 +1,5 @@
 import type { IProduct, IProductPaginationResult, IProductUpdateResponse } from '../models';
 import type Shipstation from '../shipstation';
-import { RequestMethod } from '../shipstation';
 import { BaseResource } from './Base';
 
 export class Products extends BaseResource<IProduct> {
@@ -10,19 +9,16 @@ export class Products extends BaseResource<IProduct> {
 
   /**
    * Get all products currently available in ShipStation
-   * @param {object} opts - Query parameters
+   * @param {object} params - Query parameters
    * @returns {Promise<IProductPaginationResult>}
    * @see https://www.shipstation.com/docs/api/products/list/
    */
-  public async getAll(opts?: object): Promise<IProductPaginationResult> {
-    const query = this.buildQueryStringFromParams(opts);
-    const url = this.baseUrl + query;
-
-    const response = await this.shipstation.request({
-      url,
-      method: RequestMethod.GET
+  public async getAll(params?: object): Promise<IProductPaginationResult> {
+    return this.shipstation.request<IProductPaginationResult>({
+      url: this.baseUrl,
+      method: 'GET',
+      params
     });
-    return response.data as IProductPaginationResult;
   }
 
   /**
@@ -36,13 +32,10 @@ export class Products extends BaseResource<IProduct> {
       throw new Error('Product ID is required');
     }
 
-    const url = `${this.baseUrl}/${data.productId}`;
-    const response = await this.shipstation.request({
-      url,
-      method: RequestMethod.PUT,
+    return this.shipstation.request<IProductUpdateResponse>({
+      url: `${this.baseUrl}/${data.productId}`,
+      method: 'PUT',
       data
     });
-
-    return response.data as IProductUpdateResponse;
   }
 }

--- a/src/resources/Shipments.ts
+++ b/src/resources/Shipments.ts
@@ -2,7 +2,6 @@ import type { IShipment, IShippingRate, IShippingRateOptions } from '../models';
 import type { ICreateLabelOptions } from '../models/CreateLabelOptions';
 import type { IVoidLabel, IVoidLabelOptions } from '../models/VoidLabel';
 import type Shipstation from '../shipstation';
-import { RequestMethod } from '../shipstation';
 import { BaseResource } from './Base';
 
 export class Shipments extends BaseResource<IShipment> {
@@ -10,47 +9,35 @@ export class Shipments extends BaseResource<IShipment> {
     super(shipstation, 'shipments');
   }
 
-  public async getAll(opts?: object): Promise<Array<IShipment>> {
-    const query = this.buildQueryStringFromParams(opts);
-    const url = this.baseUrl + query;
-
-    const response = await this.shipstation.request({
-      url,
-      method: RequestMethod.GET
+  public async getAll(params?: object): Promise<Array<IShipment>> {
+    return this.shipstation.request<Array<IShipment>>({
+      url: this.baseUrl,
+      method: 'GET',
+      params
     });
-    return response.data as Array<IShipment>;
   }
 
   public async getRates(data?: IShippingRateOptions): Promise<Array<IShippingRate>> {
-    const url = this.baseUrl + '/getrates';
-
-    const response = await this.shipstation.request({
-      url,
-      method: RequestMethod.POST,
+    return this.shipstation.request<Array<IShippingRate>>({
+      url: `${this.baseUrl}/getrates`,
+      method: 'POST',
       data
     });
-    return response.data as Array<IShippingRate>;
   }
 
   public async createLabel(data: ICreateLabelOptions): Promise<IShipment> {
-    const url = this.baseUrl + '/createlabel';
-
-    const response = await this.shipstation.request({
-      url,
-      method: RequestMethod.POST,
+    return this.shipstation.request<IShipment>({
+      url: `${this.baseUrl}/createlabel`,
+      method: 'POST',
       data
     });
-    return response.data as IShipment;
   }
 
   public async voidLabel(data: IVoidLabelOptions): Promise<IVoidLabel> {
-    const url = this.baseUrl + '/voidlabel';
-
-    const response = await this.shipstation.request({
-      url,
-      method: RequestMethod.POST,
+    return this.shipstation.request<IVoidLabel>({
+      url: `${this.baseUrl}/voidlabel`,
+      method: 'POST',
       data
     });
-    return response.data as IVoidLabel;
   }
 }

--- a/src/resources/Stores.ts
+++ b/src/resources/Stores.ts
@@ -1,6 +1,5 @@
 import type { IStore } from '../models';
 import type Shipstation from '../shipstation';
-import { RequestMethod } from '../shipstation';
 import { BaseResource } from './Base';
 
 export interface IGetAllStoresOptions {
@@ -13,25 +12,11 @@ export class Stores extends BaseResource<IStore> {
     super(shipstation, 'stores');
   }
 
-  public async getAll(opts?: IGetAllStoresOptions): Promise<Array<IStore>> {
-    let url = this.baseUrl;
-
-    if (typeof opts !== 'undefined') {
-      if (typeof opts.showInactive !== 'undefined') {
-        url += `?showInactive=${opts.showInactive}`;
-      }
-
-      if (typeof opts.marketplaceId !== 'undefined') {
-        const marketplaceQuery = `marketplaceId=${opts.marketplaceId}`;
-        url += url.includes('?') ? `&${marketplaceQuery}` : `?${marketplaceQuery}`;
-      }
-    }
-
-    const response = await this.shipstation.request({
-      url,
-      method: RequestMethod.GET
+  public async getAll(params?: IGetAllStoresOptions): Promise<Array<IStore>> {
+    return this.shipstation.request<Array<IStore>>({
+      params,
+      url: this.baseUrl,
+      method: 'GET'
     });
-
-    return response.data as Array<IStore>;
   }
 }

--- a/src/resources/Warehouses.ts
+++ b/src/resources/Warehouses.ts
@@ -1,6 +1,5 @@
 import type { ICreateOrUpdateWarehouse, IUpdateOrDeleteWarehouseResponse, IWarehouse } from '../models';
 import type Shipstation from '../shipstation';
-import { RequestMethod } from '../shipstation';
 import { BaseResource } from './Base';
 
 export class Warehouses extends BaseResource<IWarehouse> {
@@ -8,44 +7,33 @@ export class Warehouses extends BaseResource<IWarehouse> {
     super(shipstation, 'warehouses');
   }
 
-  public async getAll(opts?: object): Promise<Array<IWarehouse>> {
-    const query = this.buildQueryStringFromParams(opts);
-    const url = this.baseUrl + query;
-
-    const response = await this.shipstation.request({
-      url,
-      method: RequestMethod.GET
+  public async getAll(): Promise<Array<IWarehouse>> {
+    return this.shipstation.request<Array<IWarehouse>>({
+      url: this.baseUrl,
+      method: 'GET'
     });
-    return response.data as Array<IWarehouse>;
   }
 
   public async create(data: ICreateOrUpdateWarehouse): Promise<IWarehouse> {
-    const url = `${this.baseUrl}/createwarehouse`;
-    const response = await this.shipstation.request({
-      url,
-      method: RequestMethod.POST,
+    return this.shipstation.request<IWarehouse>({
+      url: `${this.baseUrl}/createwarehouse`,
+      method: 'POST',
       data
     });
-    return response.data as IWarehouse;
   }
 
   public async update(id: number, data: ICreateOrUpdateWarehouse): Promise<IUpdateOrDeleteWarehouseResponse> {
-    const url = `${this.baseUrl}/${id}`;
-    const response = await this.shipstation.request({
-      url,
-      method: RequestMethod.PUT,
+    return this.shipstation.request<IUpdateOrDeleteWarehouseResponse>({
+      url: `${this.baseUrl}/${id}`,
+      method: 'PUT',
       data
     });
-    return response.data as IUpdateOrDeleteWarehouseResponse;
   }
 
   public async delete(id: number): Promise<IUpdateOrDeleteWarehouseResponse> {
-    const url = `${this.baseUrl}/${id}`;
-    const response = await this.shipstation.request({
-      url,
-      method: RequestMethod.DELETE
+    return this.shipstation.request<IUpdateOrDeleteWarehouseResponse>({
+      url: `${this.baseUrl}/${id}`,
+      method: 'DELETE'
     });
-
-    return response.data as IUpdateOrDeleteWarehouseResponse;
   }
 }

--- a/src/resources/Webhooks.ts
+++ b/src/resources/Webhooks.ts
@@ -1,6 +1,5 @@
 import type { ISubscribeToWebhookOpts, ISubscriptionResponse, IWebhook, IWebhookResult } from '../models';
 import type Shipstation from '../shipstation';
-import { RequestMethod } from '../shipstation';
 import { BaseResource } from './Base';
 
 export class Webhooks extends BaseResource<IWebhook> {
@@ -9,29 +8,24 @@ export class Webhooks extends BaseResource<IWebhook> {
   }
 
   public async getAll(): Promise<IWebhookResult> {
-    const url = this.baseUrl;
-    const response = await this.shipstation.request({
-      url,
-      method: RequestMethod.GET
+    return this.shipstation.request<IWebhookResult>({
+      url: this.baseUrl,
+      method: 'GET'
     });
-    return response.data as IWebhookResult;
   }
 
   public async subscribe(data: ISubscribeToWebhookOpts): Promise<ISubscriptionResponse> {
-    const url = `${this.baseUrl}/subscribe`;
-    const response = await this.shipstation.request({
-      url,
-      method: RequestMethod.POST,
+    return this.shipstation.request<ISubscriptionResponse>({
+      url: `${this.baseUrl}/subscribe`,
+      method: 'POST',
       data
     });
-    return response.data as ISubscriptionResponse;
   }
 
   public async unsubscribe(id: number): Promise<null> {
-    const url = `${this.baseUrl}/${id}`;
     await this.shipstation.request({
-      url,
-      method: RequestMethod.DELETE
+      url: `${this.baseUrl}/${id}`,
+      method: 'DELETE'
     });
 
     return null;

--- a/src/shipstation.ts
+++ b/src/shipstation.ts
@@ -27,7 +27,6 @@ export default class Shipstation {
   public authorizationToken: string;
   public partnerKey?: string;
   private readonly timeout?: number;
-  protected readonly baseUrl: string = 'https://ssapi.shipstation.com/';
 
   constructor(options?: IShipstationOptions) {
     const key = options?.apiKey ? options.apiKey : process.env.SS_API_KEY;
@@ -56,6 +55,7 @@ export default class Shipstation {
 
   public request = async <T>({ data, method = 'GET', params, url }: IShipstationRequestOptions) => {
     const response = await axios.request<T>({
+      baseURL: 'https://ssapi.shipstation.com/',
       headers: {
         Authorization: `Basic ${this.authorizationToken}`,
         ...(this.partnerKey ? { 'x-partner': this.partnerKey } : {})

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -8,7 +8,6 @@ import { Stores } from './resources/Stores';
 import { Warehouses } from './resources/Warehouses';
 import { Webhooks } from './resources/Webhooks';
 import type { IShipstationRequestOptions, IShipstationOptions } from './shipstation';
-import { RequestMethod } from './shipstation';
 import { Products } from './resources/Products';
 export default class ShipStationAPI {
     private readonly ss;
@@ -24,4 +23,4 @@ export default class ShipStationAPI {
     constructor(options?: IShipstationOptions);
 }
 export type { IShipstationRequestOptions };
-export { Models, RequestMethod };
+export { Models };

--- a/typings/resources/Base.d.ts
+++ b/typings/resources/Base.d.ts
@@ -4,5 +4,4 @@ export declare class BaseResource<T> {
     protected baseUrl: string;
     constructor(shipstation: Shipstation, baseUrl: string);
     get(id: number): Promise<T>;
-    protected buildQueryStringFromParams(params?: object): string;
 }

--- a/typings/resources/Base.d.ts
+++ b/typings/resources/Base.d.ts
@@ -1,5 +1,5 @@
 import type Shipstation from '../shipstation';
-export declare class BaseResource<T> {
+export declare abstract class BaseResource<T> {
     protected shipstation: Shipstation;
     protected baseUrl: string;
     constructor(shipstation: Shipstation, baseUrl: string);

--- a/typings/resources/Fulfillments.d.ts
+++ b/typings/resources/Fulfillments.d.ts
@@ -4,5 +4,5 @@ import { BaseResource } from './Base';
 export declare class Fulfillments extends BaseResource<IFulfillment> {
     protected shipstation: Shipstation;
     constructor(shipstation: Shipstation);
-    getAll(opts?: object): Promise<IFulfillmentPaginationResult>;
+    getAll(params?: object): Promise<IFulfillmentPaginationResult>;
 }

--- a/typings/resources/Orders.d.ts
+++ b/typings/resources/Orders.d.ts
@@ -4,7 +4,7 @@ import { BaseResource } from './Base';
 export declare class Orders extends BaseResource<IOrder> {
     protected shipstation: Shipstation;
     constructor(shipstation: Shipstation);
-    getAll(opts?: object): Promise<IOrderPaginationResult>;
+    getAll(params?: object): Promise<IOrderPaginationResult>;
     createOrUpdate(data: ICreateOrUpdateOrder): Promise<IOrder>;
     createOrUpdateBulk(data: Array<ICreateOrUpdateOrder>): Promise<ICreateOrUpdateOrderBulkResponse>;
     createLabel(data: ICreateLabel): Promise<ICreateLabelResponse>;

--- a/typings/resources/Products.d.ts
+++ b/typings/resources/Products.d.ts
@@ -4,6 +4,6 @@ import { BaseResource } from './Base';
 export declare class Products extends BaseResource<IProduct> {
     protected shipstation: Shipstation;
     constructor(shipstation: Shipstation);
-    getAll(opts?: object): Promise<IProductPaginationResult>;
+    getAll(params?: object): Promise<IProductPaginationResult>;
     update(data: IProduct): Promise<IProductUpdateResponse>;
 }

--- a/typings/resources/Shipments.d.ts
+++ b/typings/resources/Shipments.d.ts
@@ -6,7 +6,7 @@ import { BaseResource } from './Base';
 export declare class Shipments extends BaseResource<IShipment> {
     protected shipstation: Shipstation;
     constructor(shipstation: Shipstation);
-    getAll(opts?: object): Promise<Array<IShipment>>;
+    getAll(params?: object): Promise<Array<IShipment>>;
     getRates(data?: IShippingRateOptions): Promise<Array<IShippingRate>>;
     createLabel(data: ICreateLabelOptions): Promise<IShipment>;
     voidLabel(data: IVoidLabelOptions): Promise<IVoidLabel>;

--- a/typings/resources/Stores.d.ts
+++ b/typings/resources/Stores.d.ts
@@ -8,5 +8,5 @@ export interface IGetAllStoresOptions {
 export declare class Stores extends BaseResource<IStore> {
     protected shipstation: Shipstation;
     constructor(shipstation: Shipstation);
-    getAll(opts?: IGetAllStoresOptions): Promise<Array<IStore>>;
+    getAll(params?: IGetAllStoresOptions): Promise<Array<IStore>>;
 }

--- a/typings/resources/Warehouses.d.ts
+++ b/typings/resources/Warehouses.d.ts
@@ -4,7 +4,7 @@ import { BaseResource } from './Base';
 export declare class Warehouses extends BaseResource<IWarehouse> {
     protected shipstation: Shipstation;
     constructor(shipstation: Shipstation);
-    getAll(opts?: object): Promise<Array<IWarehouse>>;
+    getAll(): Promise<Array<IWarehouse>>;
     create(data: ICreateOrUpdateWarehouse): Promise<IWarehouse>;
     update(id: number, data: ICreateOrUpdateWarehouse): Promise<IUpdateOrDeleteWarehouseResponse>;
     delete(id: number): Promise<IUpdateOrDeleteWarehouseResponse>;

--- a/typings/shipstation.d.ts
+++ b/typings/shipstation.d.ts
@@ -1,15 +1,7 @@
+import type { AxiosRequestConfig } from 'axios';
 import type { IAxiosRetryConfig } from 'axios-retry';
-export declare const RequestMethod: {
-    readonly GET: "GET";
-    readonly POST: "POST";
-    readonly PUT: "PUT";
-    readonly DELETE: "DELETE";
-};
-export interface IShipstationRequestOptions {
-    url: string;
-    method?: keyof typeof RequestMethod;
-    useBaseUrl?: boolean;
-    data?: any;
+export interface IShipstationRequestOptions extends Pick<AxiosRequestConfig, 'data' | 'params' | 'url'> {
+    method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
 }
 export interface IShipstationOptions {
     apiKey?: string;
@@ -21,8 +13,8 @@ export interface IShipstationOptions {
 export default class Shipstation {
     authorizationToken: string;
     partnerKey?: string;
-    private readonly baseUrl;
     private readonly timeout?;
+    protected readonly baseUrl: string;
     constructor(options?: IShipstationOptions);
-    request: ({ url, method, useBaseUrl, data }: IShipstationRequestOptions) => Promise<import("axios").AxiosResponse<any, any>>;
+    request: <T>({ data, method, params, url }: IShipstationRequestOptions) => Promise<T>;
 }

--- a/typings/shipstation.d.ts
+++ b/typings/shipstation.d.ts
@@ -14,7 +14,6 @@ export default class Shipstation {
     authorizationToken: string;
     partnerKey?: string;
     private readonly timeout?;
-    protected readonly baseUrl: string;
     constructor(options?: IShipstationOptions);
     request: <T>({ data, method, params, url }: IShipstationRequestOptions) => Promise<T>;
 }


### PR DESCRIPTION
* Remove unnecessary RequestMethod object
* Utilize native axios query string parameter building
* Remove unused useBaseUrl parameter
* Extend shipstation request options from axios options
* Simplify underlying axios request parameters
* Use generics for all requests and return data from base request